### PR TITLE
Add labels and use apostrophe prefix for chars

### DIFF
--- a/src/gasm.py
+++ b/src/gasm.py
@@ -84,10 +84,6 @@ def gasm():
                 if len(comps) > 3:
                     rb = hex(int(comps[3])).split('x')[-1]
                 
-                    
-                    
-                                
-
                 # convert to hex
                 if instr == 'end':
                     o.write('ffff\n')

--- a/src/gasm.py
+++ b/src/gasm.py
@@ -75,7 +75,6 @@ def gasm():
                     rt = hex(int(comps[1])).split('x')[-1]
                     if instr in ['movl', 'movh'] and len(comps) > 2 and comps[2] in labels:
                         imm = hex(labels[comps[2]]).split('x')[-1]
-                        print(labels[comps[2]])
                         imm = f'0{imm}' if len(imm) == 1 else imm
                     else:
                         ra = hex(int(comps[2])).split('x')[-1]

--- a/src/gasm.py
+++ b/src/gasm.py
@@ -1,20 +1,39 @@
 import sys
 import os
 
+def resolve_labels(lines):
+    labels = {}
+    resolved_lines = []
+
+    for line in lines:
+        line = line.strip()
+        if ':' in line:
+            label, _ = line.split(':')
+            if label.lower() in ['end', 'sub', 'movl', 'movh', 'jz', 'jnz', 'js', 'jns', 'ld', 'st']:
+                print(f'INVALID LABEL ({label}) AT LINE {len(resolved_lines)}')
+                exit(1)
+            labels[label] = len(resolved_lines)*2-2
+        else:
+            resolved_lines.append(line)
+
+    return resolved_lines, labels
+
 def gasm():
     source = sys.argv[1]
-
     if (len(sys.argv) > 2):
         dest = sys.argv[2]
     else:
-        # deduce dest
+        # deduce dest path
         path = source.split('/')
         source_name = os.path.splitext(path[len(path) - 1])[0]
         dest = f'{source_name}.hex'
 
     with open(dest, 'w') as o:
         with open(source) as i:
-            for line_num, line in enumerate(i):
+            lines = i.readlines()
+            lines, labels = resolve_labels(lines)
+
+            for line_num, line in enumerate(lines):
                 # remove newline
                 line = line.replace('\n', '').strip()
 
@@ -33,7 +52,6 @@ def gasm():
                     o.write(f'{line}\n')
                     continue
 
-
                 # extract comment
                 comment = ''
                 if '//' in line:
@@ -41,21 +59,38 @@ def gasm():
                     comment = line[comment_index:]
                     line = line[:comment_index].strip()
 
+                # insert char
+                if "'" in line:
+                    char_index = line.index("'")
+                    char = line[char_index + 1]
+                    line = line[:char_index] + str(ord(char)) + line[char_index + 2:]
                 # remove symbols
                 line = line.replace(',', '').replace('r', '').replace('#', '').lower()
 
                 # filter out whitespace
                 u_comps = line.split(' ')
                 comps = list(filter(lambda c: c != '' and c != ' ' and c != '\t', u_comps))
-
                 instr = comps[0]
                 if len(comps) > 1:
-                    rt = hex(int(comps[1])).split('x')[-1]
-                    ra = hex(int(comps[2])).split('x')[-1]
-                    imm = hex(int(comps[2])).split('x')[-1]
-                    imm = f'0{imm}' if len(imm) == 1 else imm
-                if len(comps) > 3:
-                    rb = hex(int(comps[3])).split('x')[-1]
+                    try:
+                        rt = hex(int(comps[1])).split('x')[-1]
+                        ra = hex(int(comps[2])).split('x')[-1]
+                        imm = comps[2]
+                        if len(comps) > 3:
+                            rb = hex(int(comps[3])).split('x')[-1]
+                    except:
+                        pass
+
+                    # resolve labels
+                    if instr in ['movl', 'movh']:
+                        if comps[2] in labels:
+                            imm = hex(labels[comps[2]])[2:].zfill(2)
+                        else:
+                            try:
+                                imm = hex(int(imm))[2:].zfill(2)
+                            except ValueError:
+                                print(f'UNDEFINED LABEL OR INVALID IMMEDIATE ({imm}) AT LINE {line_num}')
+                                exit(1)
 
                 # convert to hex
                 if instr == 'end':
@@ -67,13 +102,13 @@ def gasm():
                 elif instr == 'movh':
                     o.write(f'9{imm}{rt}\t{comment}\n')
                 elif instr == 'jz':
-                    o.write(f'e{ra}0{rt}\t{comment}\n')
+                    o.write(f'e{ra}0{imm}\t{comment}\n')
                 elif instr == 'jnz':
-                    o.write(f'e{ra}1{rt}\t{comment}\n')
+                    o.write(f'e{ra}1{imm}\t{comment}\n')
                 elif instr == 'js':
-                    o.write(f'e{ra}2{rt}\t{comment}\n')
+                    o.write(f'e{ra}2{imm}\t{comment}\n')
                 elif instr == 'jns':
-                    o.write(f'e{ra}3{rt}\t{comment}\n')
+                    o.write(f'e{ra}3{imm}\t{comment}\n')
                 elif instr == 'ld':
                     o.write(f'f{ra}0{rt}\t{comment}\n')
                 elif instr == 'st':

--- a/src/gasm.py
+++ b/src/gasm.py
@@ -72,25 +72,21 @@ def gasm():
                 comps = list(filter(lambda c: c != '' and c != ' ' and c != '\t', u_comps))
                 instr = comps[0]
                 if len(comps) > 1:
-                    try:
-                        rt = hex(int(comps[1])).split('x')[-1]
+                    rt = hex(int(comps[1])).split('x')[-1]
+                    if instr in ['movl', 'movh'] and len(comps) > 2 and comps[2] in labels:
+                        imm = hex(labels[comps[2]]).split('x')[-1]
+                        print(labels[comps[2]])
+                        imm = f'0{imm}' if len(imm) == 1 else imm
+                    else:
                         ra = hex(int(comps[2])).split('x')[-1]
-                        imm = comps[2]
-                        if len(comps) > 3:
-                            rb = hex(int(comps[3])).split('x')[-1]
-                    except:
-                        pass
-
-                    # resolve labels
-                    if instr in ['movl', 'movh']:
-                        if comps[2] in labels:
-                            imm = hex(labels[comps[2]])[2:].zfill(2)
-                        else:
-                            try:
-                                imm = hex(int(imm))[2:].zfill(2)
-                            except ValueError:
-                                print(f'UNDEFINED LABEL OR INVALID IMMEDIATE ({imm}) AT LINE {line_num}')
-                                exit(1)
+                        imm = hex(int(comps[2])).split('x')[-1]
+                        imm = f'0{imm}' if len(imm) == 1 else imm
+                if len(comps) > 3:
+                    rb = hex(int(comps[3])).split('x')[-1]
+                
+                    
+                    
+                                
 
                 # convert to hex
                 if instr == 'end':
@@ -102,20 +98,21 @@ def gasm():
                 elif instr == 'movh':
                     o.write(f'9{imm}{rt}\t{comment}\n')
                 elif instr == 'jz':
-                    o.write(f'e{ra}0{imm}\t{comment}\n')
+                    o.write(f'e{ra}0{rt}\t{comment}\n')
                 elif instr == 'jnz':
-                    o.write(f'e{ra}1{imm}\t{comment}\n')
+                    o.write(f'e{ra}1{rt}\t{comment}\n')
                 elif instr == 'js':
-                    o.write(f'e{ra}2{imm}\t{comment}\n')
+                    o.write(f'e{ra}2{rt}\t{comment}\n')
                 elif instr == 'jns':
-                    o.write(f'e{ra}3{imm}\t{comment}\n')
+                    o.write(f'e{ra}3{rt}\t{comment}\n')
                 elif instr == 'ld':
                     o.write(f'f{ra}0{rt}\t{comment}\n')
                 elif instr == 'st':
                     o.write(f'f{ra}1{rt}\t{comment}\n')
                 else:
-                    print(f'INVALID ASM INSTRUCTION ({line}) AT LINE {line_num}')
-                    exit(1)
+                    o.write(f'ffff\n')
+                    print(f'INVALID ASM INSTRUCTION ({line}) AT LINE {line_num}, will be replaced with 0xffff')
+                    # exit(1)
 
 if __name__ == '__main__':
     gasm()


### PR DESCRIPTION
```
@0
movl r1, #94 
movl r2, thing
jnz r1, r2
movl r3, 's
movl r4, 'n
thing:
movl r0, 't
movl r0, #32
```
becomes the following below after dasm

```
~~~ GENERATED BY DASM ~~~
~~~ DISSASSEMBLY OF test.hex ~~~
@0
<85e1>: movl r1, #94
<80c2>: movl r2, #12
<8714>: movl r4, #113
<e212>: jnz r2, r2
<8733>: movl r3, #115
<86e4>: movl r4, #110
<8740>: movl r0, #116
<8040>: movl r0, #4
```
